### PR TITLE
Conditionally load admin JS in footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -8,6 +8,8 @@
 	</div>
 </footer>
 
+<?php if (isset($isAdminPage) && $isAdminPage): ?>
 <script src="/assets/js/admin.js"></script>
+<?php endif; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load the admin JavaScript only when `$isAdminPage` is set, keeping public pages free of admin scripts.

## Testing
- `php -l footer.php`

------
https://chatgpt.com/codex/tasks/task_e_68bf0d738438832abb2f7a8fa688dc5b